### PR TITLE
added stopAll function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ mock('http', { request: function() {
 var http = require('http');
 http.request(); // 'http.request called'
 ```
+
 ##API
-```javascript
-mock(path, mockExport)
-```
+
+###`mock(path, mockExport)`
 
 __path__: `String`
 
@@ -65,10 +65,9 @@ var mock = require('mock-require');
 mock('../some/other/dependency', './spy');
 ...
 ```
----
-```javascript
-mock.stop(path)
-```
+
+###`mock.stop(path)`
+
 __path__: `String`
 
 The module you that you want to stop mocking.  This is the same string you would pass in if you wanted to `require` the module.
@@ -88,5 +87,28 @@ var fs2 = require('fs');
 fs1 === fs2; // false
 ```
 
+###`mock.stopAll()`
+
+This function can be used to remove all registered mocks without the need to remove them individually using `mock.stop()`.
+
+```javascript
+mock('fs', {});
+mock('path', {});
+
+var fs1 = require('fs');
+var path1 = require('path');
+
+mock.stopAll();
+
+var fs2 = require('fs');
+var path2 = require('path');
+
+fs1 === fs2; // false
+path1 === path2; // false
+```
+
 ##Test
+
+```
 npm test
+```

--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ function stopMocking(path) {
   delete intercept[getFullPath(path, calledFrom)];
 }
 
+function stopMockingAll() {
+  intercept = {};
+}
+
 function getFullPath(path, calledFrom) {
   var needsFullPath = true
     , resolvedPath
@@ -58,3 +62,4 @@ function getFullPath(path, calledFrom) {
 
 module.exports = startMocking;
 module.exports.stop = stopMocking;
+module.exports.stopAll = stopMockingAll;

--- a/test/index.js
+++ b/test/index.js
@@ -94,4 +94,16 @@ var assert  = require('assert')
   mock.stop('./throw-exception');
 })();
 
+(function shouldUnregisterAllMocks() {
+  mock('fs', {});
+  mock('path', {});
+  var fsMock = require('fs');
+  var pathMock = require('path');
+
+  mock.stopAll();
+
+  assert.notEqual(require('fs'), fsMock);
+  assert.notEqual(require('path'), pathMock);
+})();
+
 console.log('All tests pass!');


### PR DESCRIPTION
This commit adds the `stopAll` function that will remove all registered mocks in a single function call, without the need to call `mock.stop` individually for each registered mock.