### PR TITLE
Make os agnostic and add ability to mock modules that are not installed 

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function getFullPath(path, calledFrom) {
 
   try {
     resolvedPath = require.resolve(path);
-    isExternal = resolvedPath.indexOf('/node_modules/') !== -1;
+    isExternal = /[/\\]{1}node_modules[/\\]{1}/.test(resolvedPath);
 
     needsFullPath = resolvedPath !== path && !isExternal;
 

--- a/index.js
+++ b/index.js
@@ -39,17 +39,22 @@ function getFullPath(path, calledFrom) {
     resolvedPath = require.resolve(path);
   } catch(e) { }
 
-  var isExternal = /[/\\]{1}node_modules[/\\]{1}/.test(resolvedPath);
+  var isExternal = /[/\\]node_modules[/\\]/.test(resolvedPath);
   var isSystemModule = resolvedPath === path;
   if (isExternal || isSystemModule) {
     return resolvedPath;
   }
 
+  var isLocalModule = /^\.{1,2}[/\\]/.test(path);
+  if (!isLocalModule) {
+    return path;
+  }
+
+  var localModuleName = join(dirname(calledFrom), path);
   try {
-    var localModuleName = join(dirname(calledFrom), path);
     return Module._resolveFilename(localModuleName);
   } catch (e) {
-    if (isModuleNotFoundError(e)) { return path; }
+    if (isModuleNotFoundError(e)) { return localModuleName; }
     else { throw e; }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -106,4 +106,28 @@ var assert  = require('assert')
   assert.notEqual(require('path'), pathMock);
 })();
 
+(function shouldRegisterMockForModuleThatIsNotFound() {
+  var moduleName = 'module-that-is-not-installed';
+  mock(moduleName, {mocked: true});
+
+  var notInstalled = require(moduleName);
+
+  assert.equal(notInstalled.mocked, true);
+
+  mock.stop(moduleName);
+})();
+
+(function shouldUnRegisterMockForModuleThatIsNotFound() {
+  var moduleName = 'module-that-is-not-installed';
+
+  mock(moduleName, {mocked: true});
+  mock.stop(moduleName);
+
+  try{
+    require(moduleName)
+  } catch (e) {
+    assert.equal(e.code, 'MODULE_NOT_FOUND')
+  }
+})();
+
 console.log('All tests pass!');

--- a/test/index.js
+++ b/test/index.js
@@ -106,15 +106,60 @@ var assert  = require('assert')
   assert.notEqual(require('path'), pathMock);
 })();
 
-(function shouldRegisterMockForModuleThatIsNotFound() {
-  var moduleName = 'module-that-is-not-installed';
-  mock(moduleName, {mocked: true});
+(function shouldRegisterMockForExternalModuleThatIsNotFound() {
+  mock('a', {id: 'a'});
 
-  var notInstalled = require(moduleName);
+  assert.equal(require('a').id, 'a');
 
-  assert.equal(notInstalled.mocked, true);
+  mock.stopAll();
+})();
 
-  mock.stop(moduleName);
+(function shouldRegisterMultipleMocksForExternalModulesThatAreNotFound() {
+  mock('a', {id: 'a'});
+  mock('b', {id: 'b'});
+  mock('c', {id: 'c'});
+
+  assert.equal(require('a').id, 'a');
+  assert.equal(require('b').id, 'b');
+  assert.equal(require('c').id, 'c');
+
+  mock.stopAll();
+})();
+
+(function shouldRegisterMockForLocalModuleThatIsNotFound() {
+  mock('./a', {id: 'a'});
+
+  assert.equal(require('./a').id, 'a');
+
+  mock.stopAll();
+})();
+
+(function shouldRegisterMockForLocalModuleThatIsNotFound_2() {
+  mock('../a', {id: 'a'});
+
+  assert.equal(require('../a').id, 'a');
+
+  mock.stopAll();
+})();
+
+(function shouldRegisterMockForLocalModuleThatIsNotFoundAtCorrectPath() {
+  mock('./x', {id: 'x'});
+
+  assert.equal(require('./nested/module-c').dependentOn.id, 'x');
+
+  mock.stopAll();
+})();
+
+(function shouldRegisterMultipleMocksForLocalModulesThatAreNotFound() {
+  mock('./a', {id: 'a'});
+  mock('./b', {id: 'b'});
+  mock('./c', {id: 'c'});
+
+  assert.equal(require('./a').id, 'a');
+  assert.equal(require('./b').id, 'b');
+  assert.equal(require('./c').id, 'c');
+
+  mock.stopAll();
 })();
 
 (function shouldUnRegisterMockForModuleThatIsNotFound() {
@@ -128,6 +173,17 @@ var assert  = require('assert')
   } catch (e) {
     assert.equal(e.code, 'MODULE_NOT_FOUND')
   }
+})();
+
+(function shouldLoadMockedExternalModuleWhenLocalModuleHasSameName() {
+  mock('module-a', {id: 'external-module-a'});
+
+  var b = require('./module-b')
+
+  assert.equal(b.dependentOn.id, 'local-module-a')
+  assert.equal(b.dependentOn.dependentOn.id, 'external-module-a')
+
+  mock.stop(moduleName);
 })();
 
 console.log('All tests pass!');

--- a/test/index.js
+++ b/test/index.js
@@ -183,7 +183,7 @@ var assert  = require('assert')
   assert.equal(b.dependentOn.id, 'local-module-a')
   assert.equal(b.dependentOn.dependentOn.id, 'external-module-a')
 
-  mock.stop(moduleName);
+  mock.stopAll();
 })();
 
 console.log('All tests pass!');

--- a/test/module-a.js
+++ b/test/module-a.js
@@ -1,0 +1,6 @@
+var a = require('module-a')
+
+module.exports = {
+  id: 'local-module-a',
+  dependentOn: a
+};

--- a/test/module-b.js
+++ b/test/module-b.js
@@ -1,0 +1,6 @@
+var a = require('./module-a')
+
+module.exports = {
+  id: 'local-module-b',
+  dependentOn: a
+};

--- a/test/nested/module-c.js
+++ b/test/nested/module-c.js
@@ -1,0 +1,6 @@
+var x = require('../x')
+
+module.exports = {
+  id: 'local-module-c',
+  dependentOn: x
+};


### PR DESCRIPTION
In this pull request I am including two changes:

1. Make mock-require os agnostic. It did not work on windows because of assumption that file path would use forward slashes.
2. Make mock-require work with modules that are not installed. mock-require was making the assumption that the module to be mocked was already installed. In some scenarios where the production environment is different that the testing environment, a module that exists in production does not exist in the testing environment. This change allows these modules to be mocked and tested in the testing environment.

I also did some refactoring as I went.

Let me know if you have any questions or ideas.