### PR TITLE
reRequire

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ fs1 === fs2; // false
 path1 === path2; // false
 ```
 
-### `mock.reRequire`
+### `mock.reRequire(path)`
 
-`reRequire` is useful if you're trying to mock a dependency for a file that has already been required in elsewhere (possibly in another test file). Normally, Node.js will cache this file, so any mocks that you make afterwards will have no effect. `reRequire` clears the cache and allows your mock to apply.
+__path__: `String`
+
+The file whose cache you want to refresh. This is useful if you're trying to mock a dependency for a file that has already been required in elsewhere (possibly in another test file). Normally, Node.js will cache this file, so any mocks that you make afterwards will have no effect. `reRequire` clears the cache and allows your mock to apply.
 
 ```javascript
 var fs = require('fs');
@@ -119,7 +121,7 @@ mock('fs', {}); // fileToTest is still using the unmocked fs module
 fileToTest = reRequire('./fileToTest'); // fileToTest is now using your mock
 ```
 
-Note that if your test file requires dependencies that in turn require the mock, those dependencies will still have the unmocked version. You must `reRequire` all files whose caches you want to be refreshed.
+Note that if your file under test requires dependencies that in turn require the mock, those dependencies will still have the unmocked version. You must `reRequire` all modules whose caches you want to be refreshed.
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ fs1 === fs2; // false
 path1 === path2; // false
 ```
 
+### `mock.reRequire`
+
+`reRequire` is useful if you're trying to mock a dependency for a file that has already been required in elsewhere (possibly in another test file). Normally, Node.js will cache this file, so any mocks that you make afterwards will have no effect. `reRequire` clears the cache and allows your mock to apply.
+
+```javascript
+var fs = require('fs');
+var fileToTest = require('./fileToTest');
+mock('fs', {}); // fileToTest is still using the unmocked fs module
+
+fileToTest = reRequire('./fileToTest'); // fileToTest is now using your mock
+```
+
+Note that if your test file requires dependencies that in turn require the mock, those dependencies will still have the unmocked version. You must `reRequire` all files whose caches you want to be refreshed.
+
 ## Test
 
 ```

--- a/README.md
+++ b/README.md
@@ -121,7 +121,17 @@ mock('fs', {}); // fileToTest is still using the unmocked fs module
 fileToTest = reRequire('./fileToTest'); // fileToTest is now using your mock
 ```
 
-Note that if your file under test requires dependencies that in turn require the mock, those dependencies will still have the unmocked version. You must `reRequire` all modules whose caches you want to be refreshed.
+Note that if the file you are testing requires dependencies that in turn require the mock, those dependencies will still have the unmocked version. You may want to `reRequire` all of your dependencies to ensure that your mock is always being used.
+
+```javascript
+var fs = require('fs');
+var anotherDep = require('./anotherDep') // requires fs as a dependency
+var fileToTest = require('./fileToTest'); // requires fs and anotherDep as a dependency
+mock('fs', {}); // fileToTest and anotherDep are still using the unmocked fs module
+
+anotherDep = reRequire('./anotherDep'); // do this to make sure fs is being mocked consistently
+fileToTest = reRequire('./fileToTest');
+```
 
 ## Test
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,12 @@ function stopMockingAll() {
   intercept = {};
 }
 
+function reRequire(path) {
+  var module = getFullPath(path, callerId.getData().filePath);
+  delete require.cache[require.resolve(module)];
+  return require(module);
+}
+
 function getFullPath(path, calledFrom) {
   var resolvedPath;
   try {
@@ -66,3 +72,4 @@ function isModuleNotFoundError(e){
 module.exports = startMocking;
 module.exports.stop = stopMocking;
 module.exports.stopAll = stopMockingAll;
+module.exports.reRequire = reRequire;


### PR DESCRIPTION
This pull request fixes an issue I experienced while writing unit tests. I was trying to write tests for a file that my co-worker had already required in an integration test. As a result, my mocks were being ignored, because when I required it in my test file Node gave me the cached version from the other file.

I've written a new method, `reRequire`, that clears the cache for a file and requires a fresh version, so that mocks have a chance to go to work. Please let me know what you think!