### PR TITLE
Ensure that module replacements are only run when require()d

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -94,6 +94,17 @@ var assert  = require('assert')
   mock.stop('./throw-exception');
 })();
 
+(function shouldLoadMockedLibOnlyWhenRequired() {
+  mock('./throw-exception', './throw-exception-when-required');
+  try{
+    require('./throw-exception-runner')
+  }
+  catch (error) {
+    assert.equal(e.message, 'this should run when required')
+  }
+  mock.stopAll();
+})();
+
 (function shouldUnregisterAllMocks() {
   mock('fs', {});
   mock('path', {});

--- a/test/throw-exception-when-required.js
+++ b/test/throw-exception-when-required.js
@@ -1,0 +1,1 @@
+throw new Error('this should run when required');


### PR DESCRIPTION
When replacing one module path with another for the purposes of testing, the
replacement module should only be 'required' when the real one would be, so
as to test error handling around require() and module initialization code in
a consuming module.
