### PR TITLE
Account for usage of NODE_PATH.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "node test/runner"
+    "test": "NODE_PATH=test/node-path node test/runner"
   },
   "repository": {
     "type": "git",

--- a/test/node-path/in-node-path.js
+++ b/test/node-path/in-node-path.js
@@ -1,0 +1,3 @@
+{
+    id: 'node-path-set'
+}

--- a/test/runner.js
+++ b/test/runner.js
@@ -208,4 +208,18 @@ var assert  = require('assert')
   mock.stopAll();
 })();
 
+(function shouldMockFilesInNodePathByFullPath() {
+  mock('in-node-path', {id: 'in-node-path'});
+
+  var b = require('in-node-path')
+  var c = require('./node-path/in-node-path');
+
+  assert.equal(b.id, 'in-node-path');
+  assert.equal(c.id, 'in-node-path');
+
+  assert.equal(b, c);
+
+  mock.stopAll();
+})();
+
 console.log('All tests pass!');


### PR DESCRIPTION
This uses `resolvedPath` for files that live in a directory that is
specified in `NODE_PATH`. This ensures that the same file is loaded when
both relative requires and requires relative to the `NODE_PATH` are
used.

Example:

```
// NODE_PATH=is-in-node-path

require('./is-in-node-path/some-func');
require('some-func');
```