### PR TITLE
Fix: reRequiring files with naming collisions with mock-require

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/node-path/index.js

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function isInNodePath(resolvedPath) {
 function getFullPath(path, calledFrom) {
   let resolvedPath;
   try {
-    resolvedPath = require.resolve(path);
+    resolvedPath = require.resolve(path, { paths: [ calledFrom ]});
   } catch (e) {
     // do nothing
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "NODE_PATH=test/node-path mocha ./test/runner"
+    "test": "cp index.js test/node-path/index.js && NODE_PATH=test/node-path mocha ./test/runner && rm test/node-path/index.js"
   },
   "repository": {
     "type": "git",

--- a/test/runner.js
+++ b/test/runner.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const normalize = require('normalize-path');
-const mock = require('..');
+const mock = require('./node-path/index');
 
 describe('Mock Require', () => {
   afterEach(() => {
@@ -77,6 +77,10 @@ describe('Mock Require', () => {
   it('should support re-requiring', () => {
     assert.equal(mock.reRequire('.'), 'root');
   });
+
+  it('should support re-requiring names with collisions', () => {
+    assert.equal(mock.reRequire('./index'), 'root')
+  })
 
   it('should cascade mocks', () => {
     mock('path', { mocked: true });


### PR DESCRIPTION
This change fixes #36 by making `require.resolve` explicit in where it is resolving from. It therefore prevents collisions with files in `mock-require`, which are themselves in the `NODE_PATH`, triggering the `isInPath` condition to return the `mock-require` file.

To illustrate the change I moved the module itself to the `NODE_PATH` for the test.