### PR TITLE
Using path.sep and cross-env to be compatible with windows systems.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const Module = require('module');
 const dirname = require('path').dirname;
 const join = require('path').join;
 const resolve = require('path').resolve;
+const pathsep = require('path').sep;
 const getCallerFile = require('get-caller-file');
 const normalize = require('normalize-path');
 const originalLoader = Module._load;
@@ -62,7 +63,7 @@ function isInNodePath(resolvedPath) {
 
   return Module.globalPaths
     .map((nodePath) => {
-      return resolve(process.cwd(), nodePath) + '/';
+      return resolve(process.cwd(), nodePath) + pathsep;
     })
     .some((fullNodePath) => {
       return resolvedPath.indexOf(fullNodePath) === 0;

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "normalize-path": "^2.1.1"
   },
   "devDependencies": {
+    "cross-env": "^5.2.0",
     "eslint": "^4.15.0",
     "mocha": "^4.1.0"
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "NODE_PATH=test/node-path mocha ./test/runner"
+    "test": "cross-env NODE_PATH=test/node-path mocha ./test/runner"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
While using your framework on a linux and a windows 7 machine in my project a noticed an inconsistent behaviour while mocking some modules. While everything went fine on my windows machine the linux machine suddenly reported test errors.
After some debugging I noticed that you are using fixed forward slash as path separator in mock-require. I then ran your unit tests on windows and noticed that they are not running on this platform. After introducing cross-env to be able to set the environment variable on both systems I saw that one unittest fails on windows. 
After changing the fixed forward slash to path.sep all tests are ok and I think that is correct this way.