### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 mock-require is useful if you want to mock `require` statements in Node.js.  I wrote it because I wanted something with a straight-forward API that would let me mock anything, from a single exported function to a standard library.
 
+Call `mock` before you `require` the corresponding module.
+
 ## Usage
 
 ```javascript


### PR DESCRIPTION
Clarify that `mock` must be called before requiring the corresponding module.