### PR TITLE
Bump node engine and tests to node >= 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - 4
-  - 6
-  - 8
+  - 10
+  - 12
+  - 14

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "homepage": "https://github.com/boblauer/mock-require",
   "engines": {
-    "node": ">=4.3.0"
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
node <= 8 has hit end-of-life: https://nodejs.org/en/about/releases/

Upgrading enables the use of new javascript language features. Users can always use older versions of mock-require to preserve support. 

This should make the Travis build pass as well.